### PR TITLE
Ruby 3 compatibility when invalidating on failure

### DIFF
--- a/lib/state_machine/integrations/active_model.rb
+++ b/lib/state_machine/integrations/active_model.rb
@@ -382,7 +382,7 @@ module StateMachine
           end
           
           default_options = default_error_message_options(object, attribute, message)
-          object.errors.add(attribute, message, options.merge(default_options))
+          object.errors.add(attribute, message, **options.merge(default_options))
         end
       end
       


### PR DESCRIPTION
Addresses argument arity issue when invalidating if using Ruby 3.

Also seen in [other fork](https://github.com/pluginaweek/state_machine/commit/af95e48912b58f827e1247fcc4c3a6ce067c8cb4)